### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/tafaust/terraform-provider-peekaping/security/code-scanning/1](https://github.com/tafaust/terraform-provider-peekaping/security/code-scanning/1)

The best way to address this problem is by specifying a `permissions` block for the workflow or, more granularly, for the `release` job. Since only the release creation step (`softprops/action-gh-release@v1`) requires elevated permissions (specifically, the ability to write releases), and because it's the only job present, we can safely set `permissions` at the job level. This should be set to `contents: write` (enables only repository contents write, including releasing) as a minimal, least-privilege requirement. No additional permissions beyond this are required for other steps in the workflow. To implement the fix, add a `permissions` key with `contents: write` under the release job in `.github/workflows/release.yml`, at the same indentation level as `runs-on`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
