### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/tafaust/terraform-provider-peekaping/security/code-scanning/6](https://github.com/tafaust/terraform-provider-peekaping/security/code-scanning/6)

The recommended fix is to add an explicit `permissions` block, at the workflow level, setting the minimum required permissions for the jobs to execute. For standard test/build workflows that only require code checkout (reading repository content), the minimal setting is `contents: read`. This should be added at the top level of the workflow, just after the `name:` and before `on:`. If a specific job required more privileges, those could be set at the job level; however, in this workflow, no steps appear to need more than basic read access. No changes are required in any job steps or other parts of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
