### PR TITLE
ApiKey header fix

### DIFF
--- a/internal/peekaping/client.go
+++ b/internal/peekaping/client.go
@@ -165,7 +165,7 @@ func (c *Client) newReq(ctx context.Context, method, path string, body any) (*ht
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if c.apiKey != "" {
-		req.Header.Set("Authorization", c.apiKey)
+		req.Header.Set("X-API-Key", c.apiKey)
 	} else if c.accessToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.accessToken)
 	}


### PR DESCRIPTION
The current version of the code uses the `Authorization` header for api key authentication, but peekaping requires the `X-API-Key` header

[Here](https://github.com/0xfurai/peekaping/blob/92d3b671eb531cec53bdf117e633d060d8fd7e30/apps/server/src/modules/api_key/middleware.go#L28) the source code of the auth middleware.
