### PR TITLE
fix: Preserve domains field when API returns empty response

### DIFF
--- a/internal/provider/resource_status_page.go
+++ b/internal/provider/resource_status_page.go
@@ -652,12 +652,17 @@ func setModelFromStatusPageWithState(m *statusPageResourceModel, from *peekaping
 	m.CreatedAt = types.StringValue(from.CreatedAt)
 	m.UpdatedAt = types.StringValue(from.UpdatedAt)
 
+	// Handle Domains - preserve state when API doesn't return them
+	// The API may not return domains in its response, so we preserve the user's configured value
 	if len(from.Domains) > 0 {
 		domains := make([]types.String, 0, len(from.Domains))
 		for _, domain := range from.Domains {
 			domains = append(domains, types.StringValue(domain))
 		}
 		m.Domains = domains
+	} else if currentState != nil && len(currentState.Domains) > 0 {
+		// API didn't return domains, preserve state
+		m.Domains = currentState.Domains
 	} else {
 		m.Domains = nil
 	}


### PR DESCRIPTION
**Description**

Fixes status page

**Problem**

When creating or updating a peekaping_status_page resource with a domains field, Terraform fails with:

```
Error: Provider produced inconsistent result after apply
.domains: was cty.ListVal([]cty.Value{cty.StringVal("status.example.com")}), but now null.
```

The Peekaping API doesn't return the domains field in its response, causing the provider to set domains to null in the
state, which conflicts with the planned value.

**Root Cause**

In setModelFromStatusPageWithState(), when from.Domains is empty, the code unconditionally sets m.Domains = nil,
discarding the user's configured value.

**Fix**

Preserve the state/plan value when the API returns empty domains, following the same pattern already used for
MonitorIDs:

```go
if len(from.Domains) > 0 {
    // Use API response
} else if currentState != nil && len(currentState.Domains) > 0 {
    m.Domains = currentState.Domains // Preserve user's value
} else {
    m.Domains = nil
}
```

**Testing**

- Created status page with domains = ["status.example.com"]
- Before fix: terraform apply fails with inconsistent result error
- After fix: terraform apply succeeds, subsequent plans show no changes

**Example**

This triggers the error and is now fixed.

```hcl
provider "peekaping" {
  # Configuration via environment variables
}

resource "peekaping_status_page" "test_domains" {
  title       = "Test Status Page"
  description = "Testing the domains field bug"
  slug        = "test-domains-bug"
  published   = false
  theme       = "auto"
  domains     = ["status.example.com"]
}

output "domains" {
  value = peekaping_status_page.test_domains.domains
}
```